### PR TITLE
Add padding to support decoding with Base64 stdlib

### DIFF
--- a/src/provider/ehr_launch.jl
+++ b/src/provider/ehr_launch.jl
@@ -212,7 +212,7 @@ function provider_ehr_launch_part_three(
         haskey(location_queryparams, "code")              || throw(ErrorException(error_msg))
     end
     authorization_code = location_queryparams["code"]::String
-    state              = location_queryparams["state"]::String
+    state              = location_queryparams["state"]::String *"=="
     state_json = Base64.base64decode(state)
     state_dict = JSON3.read(state_json)
     token_endpoint_original = state_dict[:token_endpoint]::String


### PR DESCRIPTION
Currently we can't decode without padding character, it has been fixed on master https://github.com/JuliaLang/julia/pull/44503 but for now we'll need this to make it work.