### PR TITLE
Disable the Codecov inline annotations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+    annotations: false # Disable the annotations in the "Files Changed" view of a pull request.


### PR DESCRIPTION
They make it far more difficult to read the PR diff in the "Files changed" tab.