### PR TITLE
"Something went wrong" error message: include the actual value of the `redirect_uri`

### DIFF
--- a/src/provider/ehr_launch.jl
+++ b/src/provider/ehr_launch.jl
@@ -168,7 +168,9 @@ function provider_ehr_launch_part_two(
     let
         error_msg = string(
             "Something went wrong when authenticating to the EHR. ",
-            "One possible explanation is that your `redirect_uri` value (`$(redirect_uri)`) does not exactly ",
+            "One possible explanation is that your `redirect_uri` value (`",
+            redirect_uri,
+            "`) does not exactly ",
             "match any of the `redirect_uri` values that are on file with the EHR.",
         )
         haskey(headers, "Location") || throw(ErrorException(error_msg))

--- a/src/provider/ehr_launch.jl
+++ b/src/provider/ehr_launch.jl
@@ -164,10 +164,11 @@ function provider_ehr_launch_part_two(
         "GET", authorize_uri_with_querystring_params; redirect=false
     )
     headers = Dict(authorize_response.headers)
+    redirect_uri = config.redirect_uri
     let
         error_msg = string(
             "Something went wrong when authenticating to the EHR. ",
-            "One possible explanation is that your `redirect_uri` value does not exactly ",
+            "One possible explanation is that your `redirect_uri` value (`$(redirect_uri)`) does not exactly ",
             "match any of the `redirect_uri` values that are on file with the EHR.",
         )
         haskey(headers, "Location") || throw(ErrorException(error_msg))


### PR DESCRIPTION
It can be quite hard to debug this error if the error message doesn't actually include what the value of `redirect_uri` was.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved error messages in EHR authentication, providing clearer feedback by including `redirect_uri` details for enhanced debugging.

- **Bug Fixes**
	- Enhanced clarity of error handling related to authentication issues with EHR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->